### PR TITLE
v3.0.0 - Config, dragresize, dragreorder, doubleclick-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # multiframe_list.py
 Compact raw python module that brings the MultiframeList class with it.
 It is a tkinter widget that can be used to display data split up over multiple columns.
+It integrates into the ttk styling database and applies certain style configurations to
+otherwise unstylable Listboxes.
 
 ## Installation
 Get it by running `pip install multiframe_list`
@@ -12,9 +14,8 @@ import tkinter as tk
 from multiframe_list import MultiframeList
 
 def format_price(raw):
-    cents = raw % 100
-    dollars = raw // 100
-    return "${}.{:0>2}".format(dollars, cents)
+    dollars, cents = divmod(raw, 100)
+    return f"${dollars}.{cents:0>2}"
 
 items = (
     ("Apple", 79, 42),
@@ -26,35 +27,22 @@ items = (
 root = tk.Tk()
 
 item_display = MultiframeList(root, inicolumns = (
-        {"name": "Items", "col_id": "col_items",
-         "sort": False},
-        {"name": "Price", "col_id": "col_prices",
-         "sort": True, "formatter": format_price}
-    )
-)
-
-item_display.addframes(1)
-item_display.addcolumns(
-    {"name": "Stock", "col_id": "col_qty",
-     "sort": False}
-)
-item_display.assigncolumn("col_qty", 2)
-# Manually create a frame, a column and then display the
-# new column in the freshly created third frame
-# Same effect as if you had put the dict into the inicolumns tuple
-
-item_display.grid(sticky = "nesw")
+    {"name": "Items", "col_id": "col_items", "sort": False},
+    {"name": "Price", "col_id": "col_prices", "sort": True,
+	 "formatter": format_price},
+    {"name": "Stock", "col_id": "col_qty", "sort": False},
+))
 
 item_display.setdata({
-    "col_items": [t[0] for t in items],
+    "col_items":  [t[0] for t in items],
     "col_prices": [t[1] for t in items],
-    "col_qty": [t[2] for t in items],
+    "col_qty":    [t[2] for t in items],
 })
 item_display.format()
-# Required for the price formatter, else the column would display raw values
+# Required for the price formatter or that column would display raw values
 
+item_display.grid(sticky = "nesw")
 root.mainloop()
-
 ```
 Will result in this window:
 

--- a/multiframe_list/__init__.py
+++ b/multiframe_list/__init__.py
@@ -2,5 +2,7 @@
 Make MultiframeList and run_demo available with less typing
 """
 
-from .multiframe_list import MultiframeList
-from .demo import run_demo
+from multiframe_list import multiframe_list, demo
+
+MultiframeList = multiframe_list.MultiframeList
+run_demo = demo.run_demo

--- a/multiframe_list/__main__.py
+++ b/multiframe_list/__main__.py
@@ -1,3 +1,4 @@
 from multiframe_list.demo import run_demo
 
-run_demo()
+if __name__ == "__main__":
+	run_demo()

--- a/multiframe_list/demo.py
+++ b/multiframe_list/demo.py
@@ -14,6 +14,10 @@ def priceconv(data):
 class Demo:
 	def __init__(self):
 		self.root = tk.Tk()
+		self.root.bind(
+			"<<MultiframeRightclick>>",
+			lambda e: print("Rightclick on", e.widget, "@", self.mfl.coordx, self.mfl.coordy)
+		)
 		self.mfl = MultiframeList(self.root, inicolumns=(
 			{"name": "Small", "w_width": 10},
 			{"name": "Sortercol", "col_id": "sorter"},
@@ -24,8 +28,10 @@ class Demo:
 		))
 		self.mfl.configcolumn("sickocol", formatter = priceconv)
 		self.mfl.configcolumn("sorter", sort = True)
-		self.mfl.configcolumn("cnfcl", name = "Configured Name", sort = True,
-			fallback_type = lambda x: int("0" + str(x)))
+		self.mfl.configcolumn(
+			"cnfcl", name = "Configured Name", sort = True,
+			fallback_type = lambda x: int("0" + str(x))
+		)
 		self.mfl.pack(expand = 1, fill = tk.BOTH)
 		self.mfl.addframes(2)
 		self.mfl.removeframes(1)
@@ -47,9 +53,12 @@ class Demo:
 			tk.Button(self.root, text="bgstyle",  command=lambda: self.root.tk.eval(
 				"ttk::style configure . -background #{0}{0}{0}".format(hex(randint(50, 255))[2:])
 			)),
-			tk.Button(self.root, text="lbstyle",  command=lambda: self.root.tk.eval(
-				"ttk::style configure MultiframeList.Listbox -background #{0}{0}{0} -foreground #0000{1:0>2}".format(
-					hex(randint(120, 255))[2:], hex(randint(0, 255))[2:]))),
+			tk.Button(self.root, text="lbstyle",  command=lambda: self.root.tk.eval((
+					"ttk::style configure MultiframeList.Listbox -background #{0}{0}{0} -foreground #0000{1:0>2}\n"
+					"ttk::style configure XActive.MultiframeList.Listbox -selectbackground #0000{0}\n"
+					"ttk::style configure MultiframeListReorderInd.TFrame -background #00{0}00"
+				).format(hex(randint(120, 255))[2:], hex(randint(0, 255))[2:])
+			)),
 			tk.Button(self.root, text="conf",     command=lambda: self.mfl.config(listboxheight=randint(5, 10))),
 			tk.Button(self.root, text="randsel",  command=self.randselection),
 		)

--- a/multiframe_list/demo.py
+++ b/multiframe_list/demo.py
@@ -23,7 +23,7 @@ class Demo:
 			{"name": "Sortercol", "col_id": "sorter"},
 			{"name": "Pricecol", "sort": True, "col_id": "sickocol"},
 			{"name": "-100", "col_id": "sub_col", "formatter": lambda n: n-100},
-			{"name": "Wide col", "w_width": 30},
+			{"name": "Wide col", "w_width": 30, "minsize": 200},
 			{"name": "unconf name", "col_id": "cnfcl"},
 		))
 		self.mfl.configcolumn("sickocol", formatter = priceconv)
@@ -56,7 +56,8 @@ class Demo:
 			tk.Button(self.root, text="lbstyle",  command=lambda: self.root.tk.eval((
 					"ttk::style configure MultiframeList.Listbox -background #{0}{0}{0} -foreground #0000{1:0>2}\n"
 					"ttk::style configure XActive.MultiframeList.Listbox -selectbackground #0000{0}\n"
-					"ttk::style configure MultiframeListReorderInd.TFrame -background #00{0}00"
+					"ttk::style configure MultiframeListReorderInd.TFrame -background #{0}0000\n"
+					"ttk::style configure MultiframeListResizeInd.TFrame -background #0000{0}\n"
 				).format(hex(randint(120, 255))[2:], hex(randint(0, 255))[2:])
 			)),
 			tk.Button(self.root, text="conf",     command=lambda: self.mfl.config(listboxheight=randint(5, 10))),
@@ -66,8 +67,7 @@ class Demo:
 			btn.pack(fill = tk.X, side = tk.LEFT)
 
 	def adddata(self):
-		self.mfl.insertrow({col_id: randint(0, 100)
-			for col_id in self.mfl.getcolumns()})
+		self.mfl.insertrow({col_id: randint(0, 100) for col_id in self.mfl.getcolumns()})
 		self.mfl.format()
 
 	def add1col(self):
@@ -140,9 +140,9 @@ class Demo:
 
 	def swaprand(self):
 		l = self.mfl.getcolumns().keys()
-		s_res = sample(l, 2)
-		print("Swapping {}".format(" with ".join([str(i) for i in s_res])))
-		self.swap(*s_res)
+		a, b = sample(l, 2)
+		print(f"Swapping {a} with {b}")
+		self.swap(a, b)
 
 def run_demo():
 	demo = Demo()

--- a/multiframe_list/demo2.py
+++ b/multiframe_list/demo2.py
@@ -1,11 +1,12 @@
 import tkinter as tk
 
-from multiframe_list import MultiframeList
+from multiframe_list.multiframe_list import MultiframeList
 
 def main():
 	root = tk.Tk()
 	mfl = MultiframeList(root, inicolumns =
-		({"name": "aaaa"}, {"name": "bbbb"})
+		({"name": "aaaa"}, {"name": "bbbb"}),
+		resizable = True, reorderable = True
 	)
 	mfl.pack(fill = tk.BOTH, expand = 1)
 	root.mainloop()

--- a/multiframe_list/demo2.py
+++ b/multiframe_list/demo2.py
@@ -1,0 +1,14 @@
+import tkinter as tk
+
+from multiframe_list import MultiframeList
+
+def main():
+	root = tk.Tk()
+	mfl = MultiframeList(root, inicolumns =
+		({"name": "aaaa"}, {"name": "bbbb"})
+	)
+	mfl.pack(fill = tk.BOTH, expand = 1)
+	root.mainloop()
+
+if __name__ == "__main__":
+	main()

--- a/multiframe_list/multiframe_list.py
+++ b/multiframe_list/multiframe_list.py
@@ -21,6 +21,10 @@ DRAG_THRES = 15
 ALL = "all"
 END = "end"
 
+class DRAGINTENT:
+	REORDER = 1
+	RESIZE = 2
+
 SORTSYM = ("\u25B2", "\u25BC", "\u25A0") #desc, asc, none
 
 SCROLLCOMMAND = \
@@ -218,6 +222,8 @@ class _Column():
 				self.mfl._on_column_drag(evt, self.assignedframe)
 			elif not self.dragged and abs(evt.x - self.pressed) > DRAG_THRES:
 				self.dragged = True
+		else:
+			pass # TODO continue dragging code here
 
 	def _label_on_release(self, evt):
 		if not self.dragged and self.cnf.sort:
@@ -1029,6 +1035,7 @@ class MultiframeList(ttk.Frame):
 		self.reorder_highlight.tkraise()
 
 	def _on_empty_frame_motion(self, evt, fidx):
+		self.frames[fidx][2].configure(cursor="sb_h_double_arrow")
 		if self.pressed_frame is not None:
 			if self.dragging:
 				self._on_column_drag(evt, fidx)


### PR DESCRIPTION
Introduced a semi-stable config handling scheme for both the MultiframeList and Columns.
Can now drag and resize/reorder all frames, empty or not.
Completely broke backwards compatibility by removing w_width from Columns and renaming every method to include more underscores.
Probably added at least 17 edge case related bugs.
Hopefully, it will have been worth the weight.
closes #4 
closes #2 
closes #1 as well apparently.